### PR TITLE
Use better packaging practices

### DIFF
--- a/shellphish_qemu/__init__.py
+++ b/shellphish_qemu/__init__.py
@@ -1,5 +1,4 @@
 import os
-import distutils
 
 def qemu_path(platform):
     for basename in (
@@ -8,13 +7,10 @@ def qemu_path(platform):
         '%s' % platform,
     ):
         path = os.path.join(qemu_base(), basename)
-        if os.path.exists(path):
+        if os.path.isfile(path):
             return path
 
-    return "NOT_FOUND"
+    raise ValueError('Unable to find qemu for platform "%s"' % platform)
 
 def qemu_base():
-    if __file__.startswith(distutils.sysconfig.PREFIX):
-        return os.path.join(distutils.sysconfig.PREFIX, 'bin')
-    else:
-        return os.path.join(os.path.dirname(__file__), '..', 'bin')
+    return pkg_resources.resource_filename('shellphish_qemu', 'bin')


### PR DESCRIPTION
- Store the binaries alongside the code, use pkg_resources to retrieve them
- Check that the binary we're about to return is a file, not just existing (I think this is part of the problem for that one tracer issue. basically this whole PR is a response to that issue.)
- Raise ValueError when we can't find an appropriate binary instead of just returning "NOT_FOUND"
- Bump version number

Do you want to rebuild the wheel or do you trust me to have done it correctly? :P