### PR TITLE
Fix building qemu with gcc 7 and perl 5.26

### DIFF
--- a/patches/tracer-qemu.patch
+++ b/patches/tracer-qemu.patch
@@ -103,6 +103,19 @@ index 1622ad6..1f62b47 100644
              unlock_user(p, arg2, ret);
          }
          break;
+diff --git a/scripts/texi2pod.pl b/scripts/texi2pod.pl
+index 94097fb065..d96909483a 100755
+--- a/scripts/texi2pod.pl
++++ b/scripts/texi2pod.pl
+@@ -317,7 +317,7 @@ while(<$inf>) {
+ 	@columns = ();
+ 	for $column (split (/\s*\@tab\s*/, $1)) {
+ 	    # @strong{...} is used a @headitem work-alike
+-	    $column =~ s/^\@strong{(.*)}$/$1/;
++	    $column =~ s/address@hidden(.*)\}$/$1/;
+ 	    push @columns, $column;
+ 	}
+ 	$_ = "\n=item ".join (" : ", @columns)."\n";
 diff --git a/tracer-config b/tracer-config
 new file mode 100755
 index 0000000..4a9db4a
@@ -111,7 +124,7 @@ index 0000000..4a9db4a
 @@ -0,0 +1,3 @@
 +#!/bin/sh
 +
-+./configure --target-list=i386-linux-user,x86_64-linux-user,mips-linux-user,mips64-linux-user,mipsel-linux-user,ppc-linux-user,ppc64-linux-user,arm-linux-user,aarch64-linux-user
++./configure --target-list=i386-linux-user,x86_64-linux-user,mips-linux-user,mips64-linux-user,mipsel-linux-user,ppc-linux-user,ppc64-linux-user,arm-linux-user,aarch64-linux-user --disable-werror
 -- 
 1.9.1
 


### PR DESCRIPTION
- -Werror with GCC 7 will fail build beacuse of -Wint-in-bool-context
- For the Perl issue see https://lists.nongnu.org/archive/html/qemu-devel/2015-10/msg02121.html