### PR TITLE
Added Crash Message Logging

### DIFF
--- a/patches/cgc-coredump.patch
+++ b/patches/cgc-coredump.patch
@@ -1,5 +1,5 @@
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index a8bc667..0517c0a 100644
+index a8bc667..f4d8b73 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -77,3 +77,24 @@ index 48d1abc..dc90d1f 100644
  
  abi_long memcpy_to_target(abi_ulong dest, const void *src,
                            unsigned long len);
+diff --git a/linux-user/signal.c b/linux-user/signal.c
+index 6ff19f4..3cf7f20 100644
+--- a/linux-user/signal.c
++++ b/linux-user/signal.c
+@@ -467,8 +467,14 @@ static void QEMU_NORETURN force_sig(int target_sig)
+         setrlimit(RLIMIT_CORE, &nodump);
+         qemu_log("qemu: uncaught target signal %d (%s) - %s [%08x]\n",
+             target_sig, strsignal(host_sig), "core dumped",env->eip);
+-        (void) fprintf(stderr, "qemu: uncaught target signal %d (%s) - %s\n",
+-            target_sig, strsignal(host_sig), "core dumped" );
++        (void) fprintf(stderr, "qemu: uncaught target signal %d (%s) - %s [%08x]\n",
++            target_sig, strsignal(host_sig), "core dumped", env->eip);
++    } else {
++        // log crash address even if core file is not dumped.
++        qemu_log("qemu: uncaught target signal %d (%s) - %s [%08x]\n",
++                 target_sig, strsignal(host_sig), "core not available", env->eip);
++        (void) fprintf(stderr, "qemu: uncaught target signal %d (%s) - %s [%08x]\n",
++                       target_sig, strsignal(host_sig), "core not available", env->eip);
+     }
+ 
+     /* The proper exit code for dying from an uncaught signal is


### PR DESCRIPTION
When a segfault occurs, qemu was not logging the expected crash message.  As a result, tracer.QEMURunner would not retrieve the proper crash address.   This update to the patches/cgc-coredump.patch adds that logging.
-Erik