### PR TITLE
Wip/halfway tracing

### DIFF
--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -93,7 +93,7 @@ index fcc7b9e..767c6d0 100644
  {
      QemuLogFile *logfile;
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..a769449 100644
+index 8198be0..ff764ab 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -128,43 +128,6 @@ index 8198be0..a769449 100644
  /* Here is the structure in which status of each thread is captured. */
  struct elf_thread_status {
      QTAILQ_ENTRY(elf_thread_status)  ets_link;
-@@ -3193,21 +3202,21 @@ static abi_ulong vma_dump_size(const struct vm_area_struct *vma)
-      * and check whether it contains elf header.  If there is
-      * no elf header, we dump it.
-      */
--    if (vma->vma_flags & PROT_EXEC) {
--        char page[TARGET_PAGE_SIZE];
--
--        copy_from_user(page, vma->vma_start, sizeof (page));
--        if ((page[EI_MAG0] == ELFMAG0) &&
--            (page[EI_MAG1] == ELFMAG1) &&
--            (page[EI_MAG2] == ELFMAG2) &&
--            (page[EI_MAG3] == ELFMAG3)) {
--            /*
--             * Mappings are possibly from ELF binary.  Don't dump
--             * them.
--             */
--            return (0);
--        }
--    }
-+    // if (vma->vma_flags & PROT_EXEC) {
-+    //     char page[TARGET_PAGE_SIZE];
-+
-+    //     copy_from_user(page, vma->vma_start, sizeof (page));
-+    //     if ((page[EI_MAG0] == ELFMAG0) &&
-+    //         (page[EI_MAG1] == ELFMAG1) &&
-+    //         (page[EI_MAG2] == ELFMAG2) &&
-+    //         (page[EI_MAG3] == ELFMAG3)) {
-+    //         /*
-+    //          * Mappings are possibly from ELF binary.  Don't dump
-+    //          * them.
-+    //          */
-+    //         return (0);
-+    //     }
-+    // }
- 
-     return (vma->vma_end - vma->vma_start);
- }
 @@ -3357,6 +3366,118 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
      }
  }

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -1,3 +1,37 @@
+diff --git a/accel/tcg/cpu-exec.c b/accel/tcg/cpu-exec.c
+index d95c484..e50d65e 100644
+--- a/accel/tcg/cpu-exec.c
++++ b/accel/tcg/cpu-exec.c
+@@ -138,6 +138,17 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
+ #endif /* CONFIG USER ONLY */
+ 
+ /* Execute a TB, and fix up the CPU state afterwards if necessary */
++abi_long core_addr = 0;
++void qemu_set_core_addr(const char *addr_str)
++{
++    int ret = sscanf(addr_str, "0x" TARGET_FMT_lx, &core_addr);
++    if(ret != 1) {
++        fprintf(stderr, "Fail to parse coreaddr: '%s'\n", addr_str);
++        exit(1);
++    }
++}
++
++extern int elf_core_dump(int signr, const CPUArchState *env);
+ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
+ {
+     CPUArchState *env = cpu->env_ptr;
+@@ -153,6 +164,11 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
+                            itb->cs_base, itb->pc, itb->flags,
+                            lookup_symbol(itb->pc));
+ 
++    if(unlikely(core_addr >= itb->pc && core_addr < itb->pc + itb->size)) {
++        elf_core_dump(SIGSEGV, env);
++        abort();
++    }
++
+ #if defined(DEBUG_DISAS)
+     if (qemu_loglevel_mask(CPU_LOG_TB_CPU)
+         && qemu_log_in_addr_range(itb->pc)) {
 diff --git a/include/elf.h b/include/elf.h
 index 8fbfe60..79e5fbc 100644
 --- a/include/elf.h
@@ -10,8 +44,22 @@ index 8fbfe60..79e5fbc 100644
  #define NT_S390_GS_CB   0x30b           /* s390 guarded storage registers */
  #define NT_S390_VXRS_HIGH 0x30a         /* s390 vector registers 16-31 */
  #define NT_S390_VXRS_LOW  0x309         /* s390 vector registers 0-15 (lower half) */
+diff --git a/include/exec/log.h b/include/exec/log.h
+index fcc7b9e..ca70a47 100644
+--- a/include/exec/log.h
++++ b/include/exec/log.h
+@@ -13,6 +13,9 @@
+  *
+  * Logs the output of cpu_dump_state().
+  */
++
++void qemu_set_core_addr(const char *addr_str);
++
+ static inline void log_cpu_state(CPUState *cpu, int flags)
+ {
+     QemuLogFile *logfile;
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..3921fc1 100644
+index 8198be0..2bcc4e0 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -23,6 +71,15 @@ index 8198be0..3921fc1 100644
  
  #include <sys/resource.h>
  #include <sys/shm.h>
+@@ -1659,7 +1661,7 @@ static inline void bswap_mips_abiflags(Mips_elf_abiflags_v0 *abiflags) { }
+ #endif
+ 
+ #ifdef USE_ELF_CORE_DUMP
+-static int elf_core_dump(int, const CPUArchState *);
++int elf_core_dump(int, const CPUArchState *);
+ #endif /* USE_ELF_CORE_DUMP */
+ static void load_symbols(struct elfhdr *hdr, int fd, abi_ulong load_bias);
+ 
 @@ -2999,6 +3001,13 @@ struct target_elf_prpsinfo {
      char    pr_psargs[ELF_PRARGSZ]; /* initial part of arg list */
  };
@@ -219,11 +276,20 @@ index 8198be0..3921fc1 100644
  
      info->notes_size = 0;
      for (i = 0; i < info->numnote; i++)
+@@ -3610,7 +3721,7 @@ static int write_note_info(struct elf_note_info *info, int fd)
+  * handler (provided that target process haven't registered
+  * handler for that) that does the dump when signal is received.
+  */
+-static int elf_core_dump(int signr, const CPUArchState *env)
++int elf_core_dump(int signr, const CPUArchState *env)
+ {
+     const CPUState *cpu = env_cpu((CPUArchState *)env);
+     const TaskState *ts = (const TaskState *)cpu->opaque;
 diff --git a/linux-user/main.c b/linux-user/main.c
-index 22578b1..ee5ca09 100644
+index 22578b1..24df7d1 100644
 --- a/linux-user/main.c
 +++ b/linux-user/main.c
-@@ -288,6 +288,11 @@ static void handle_arg_stack_size(const char *arg)
+@@ -288,6 +288,16 @@ static void handle_arg_stack_size(const char *arg)
      }
  }
  
@@ -232,15 +298,22 @@ index 22578b1..ee5ca09 100644
 +    qemu_set_core_dump_prefix(arg);
 +}
 +
++static void handle_arg_core_addr(const char *arg)
++{
++    qemu_set_core_addr(arg);
++}
++
  static void handle_arg_ld_prefix(const char *arg)
  {
      interp_prefix = strdup(arg);
-@@ -424,6 +429,8 @@ static const struct qemu_argument arg_table[] = {
+@@ -424,6 +434,10 @@ static const struct qemu_argument arg_table[] = {
       "",           ""},
      {"g",          "QEMU_GDB",         true,  handle_arg_gdb,
       "port",       "wait gdb connection to 'port'"},
 +    {"C",          "QEMU_CORE_PREFIX", true,  handle_arg_core,
 +     "path",       "set coredump path prefix to 'path' (default '.')"},
++    {"A",          "QEMU_CORE_ADDR",   true,  handle_arg_core_addr,
++     "coreaddr",   "generate a core dump at 'coreaddr'"},
      {"L",          "QEMU_LD_PREFIX",   true,  handle_arg_ld_prefix,
       "path",       "set the elf interpreter prefix to 'path'"},
      {"s",          "QEMU_STACK_SIZE",  true,  handle_arg_stack_size,
@@ -257,10 +330,20 @@ index 792c742..f59c86d 100644
  abi_long memcpy_to_target(abi_ulong dest, const void *src,
                            unsigned long len);
 diff --git a/linux-user/signal.c b/linux-user/signal.c
-index 8cf51ff..3322d2c 100644
+index 8cf51ff..8e3ae55 100644
 --- a/linux-user/signal.c
 +++ b/linux-user/signal.c
-@@ -627,6 +627,8 @@ static void QEMU_NORETURN dump_core_and_abort(int target_sig)
+@@ -619,14 +619,17 @@ void force_sigsegv(int oldsig)
+ 
+ #endif
+ 
++void QEMU_NORETURN dump_core_and_abort(int target_sig);
+ /* abort execution with signal */
+-static void QEMU_NORETURN dump_core_and_abort(int target_sig)
++void QEMU_NORETURN dump_core_and_abort(int target_sig)
+ {
+     CPUState *cpu = thread_cpu;
+     CPUArchState *env = cpu->env_ptr;
      TaskState *ts = (TaskState *)cpu->opaque;
      int host_sig, core_dumped = 0;
      struct sigaction act;
@@ -269,19 +352,14 @@ index 8cf51ff..3322d2c 100644
  
      host_sig = target_to_host_signal(target_sig);
      trace_user_force_sig(env, target_sig, host_sig);
-@@ -649,6 +651,16 @@ static void QEMU_NORETURN dump_core_and_abort(int target_sig)
+@@ -649,6 +652,11 @@ static void QEMU_NORETURN dump_core_and_abort(int target_sig)
              target_sig, strsignal(host_sig), "core dumped" );
      }
  
 +    cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
-+    if (sizeof(target_ulong) == 4) {
-+        qemu_log("qemu: uncaught target signal %d (%s) - %s [%08x]\n",
-+                 target_sig, strsignal(host_sig), "core dumped", (unsigned int)pc);
-+    }
-+    else if (sizeof(target_ulong) == 8) {
-+        qemu_log("qemu: uncaught target signal %d (%s) - %s [%016llx]\n",
-+                 target_sig, strsignal(host_sig), "core dumped", (unsigned long long)pc);
-+    }
++    qemu_log("qemu: uncaught target signal %d (%s) - %s [%0*llx]\n",
++             target_sig, strsignal(host_sig), "core dumped",
++             (int)sizeof(target_ulong)*2, (unsigned long long)pc);
 +
      /* The proper exit code for dying from an uncaught signal is
       * -<signal>.  The kernel doesn't allow exit() or _exit() to pass

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -93,7 +93,7 @@ index fcc7b9e..767c6d0 100644
  {
      QemuLogFile *logfile;
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..b1325a5 100644
+index 8198be0..a769449 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -416,3 +416,20 @@ index 8cf51ff..8e3ae55 100644
      /* The proper exit code for dying from an uncaught signal is
       * -<signal>.  The kernel doesn't allow exit() or _exit() to pass
       * a negative value.  To get the proper exit code we need to
+diff --git a/target/mips/translate.c b/target/mips/translate.c
+index 25b595a..f9db3cd 100644
+--- a/target/mips/translate.c
++++ b/target/mips/translate.c
+@@ -30942,9 +30942,9 @@ static void mips_tr_translate_insn(DisasContextBase *dcbase, CPUState *cs)
+         (ctx->hflags & MIPS_HFLAG_BMASK) == 0) {
+         ctx->base.is_jmp = DISAS_TOO_MANY;
+     }
+-    if (ctx->base.pc_next - ctx->page_start >= TARGET_PAGE_SIZE) {
+-        ctx->base.is_jmp = DISAS_TOO_MANY;
+-    }
++//    if (ctx->base.pc_next - ctx->page_start >= TARGET_PAGE_SIZE) {
++//        ctx->base.is_jmp = DISAS_TOO_MANY;
++//    }
+ }
+ 
+ static void mips_tr_tb_stop(DisasContextBase *dcbase, CPUState *cs)

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -93,7 +93,7 @@ index fcc7b9e..767c6d0 100644
  {
      QemuLogFile *logfile;
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..2bcc4e0 100644
+index 8198be0..b1325a5 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -165,7 +165,7 @@ index 8198be0..2bcc4e0 100644
  
      return (vma->vma_end - vma->vma_start);
  }
-@@ -3357,6 +3366,107 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
+@@ -3357,6 +3366,118 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
      }
  }
  
@@ -229,6 +229,16 @@ index 8198be0..2bcc4e0 100644
 +    abi_long *long_ptr = (abi_long *)ptr;
 +
 +    // memory mappings
++#ifdef BSWAP_NEEDED
++    long_ptr[idx++] = tswapl(count);    // number of map entries
++    long_ptr[idx++] = tswapl(TARGET_PAGE_SIZE);   // target page size
++    for(int i=0; i<count; i++) {
++        struct target_ntfile_entry *entry = &entries[i];
++        long_ptr[idx++] = tswapl(entry->vm_start);
++        long_ptr[idx++] = tswapl(entry->vm_end);
++        long_ptr[idx++] = tswapl(entry->page_offset);
++    }
++#else
 +    long_ptr[idx++] = count;    // number of map entries
 +    long_ptr[idx++] = TARGET_PAGE_SIZE;   // target page size
 +    for(int i=0; i<count; i++) {
@@ -237,6 +247,7 @@ index 8198be0..2bcc4e0 100644
 +        long_ptr[idx++] = entry->vm_end;
 +        long_ptr[idx++] = entry->page_offset;
 +    }
++#endif
 +
 +    // path names
 +    idx *= sizeof(abi_long);
@@ -273,7 +284,7 @@ index 8198be0..2bcc4e0 100644
  /*
   * Constructs name of coredump file.  We have following convention
   * for the name:
-@@ -3383,7 +3493,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
+@@ -3383,7 +3504,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
      base_filename = g_path_get_basename(ts->bprm->filename);
      (void) strftime(timestamp, sizeof (timestamp), "%Y%m%d-%H%M%S",
                      localtime_r(&tv.tv_sec, &tm));
@@ -282,7 +293,7 @@ index 8198be0..2bcc4e0 100644
                      base_filename, timestamp, (int)getpid());
      g_free(base_filename);
  
-@@ -3487,7 +3597,7 @@ static void init_note_info(struct elf_note_info *info)
+@@ -3487,7 +3608,7 @@ static void init_note_info(struct elf_note_info *info)
  static int fill_note_info(struct elf_note_info *info,
                            long signr, const CPUArchState *env)
  {
@@ -291,7 +302,7 @@ index 8198be0..2bcc4e0 100644
      CPUState *cpu = env_cpu((CPUArchState *)env);
      TaskState *ts = (TaskState *)cpu->opaque;
      int i;
-@@ -3504,7 +3614,7 @@ static int fill_note_info(struct elf_note_info *info,
+@@ -3504,7 +3625,7 @@ static int fill_note_info(struct elf_note_info *info,
  
      /*
       * First fill in status (and registers) of current thread
@@ -300,7 +311,7 @@ index 8198be0..2bcc4e0 100644
       */
      fill_prstatus(info->prstatus, ts, signr);
      elf_core_copy_regs(&info->prstatus->pr_reg, env);
-@@ -3514,7 +3624,8 @@ static int fill_note_info(struct elf_note_info *info,
+@@ -3514,7 +3635,8 @@ static int fill_note_info(struct elf_note_info *info,
      fill_note(&info->notes[1], "CORE", NT_PRPSINFO,
                sizeof (*info->psinfo), info->psinfo);
      fill_auxv_note(&info->notes[2], ts);
@@ -310,7 +321,7 @@ index 8198be0..2bcc4e0 100644
  
      info->notes_size = 0;
      for (i = 0; i < info->numnote; i++)
-@@ -3610,7 +3721,7 @@ static int write_note_info(struct elf_note_info *info, int fd)
+@@ -3610,7 +3732,7 @@ static int write_note_info(struct elf_note_info *info, int fd)
   * handler (provided that target process haven't registered
   * handler for that) that does the dump when signal is received.
   */

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -1,5 +1,17 @@
+diff --git a/include/elf.h b/include/elf.h
+index 8fbfe60..79e5fbc 100644
+--- a/include/elf.h
++++ b/include/elf.h
+@@ -1634,6 +1634,7 @@ typedef struct elf64_shdr {
+ #define NT_TASKSTRUCT	4
+ #define NT_AUXV		6
+ #define NT_PRXFPREG     0x46e62b7f      /* copied from gdb5.1/include/elf/common.h */
++#define NT_FILE     0x46494c45          /* copied from gdb5.1/include/elf/common.h */
+ #define NT_S390_GS_CB   0x30b           /* s390 guarded storage registers */
+ #define NT_S390_VXRS_HIGH 0x30a         /* s390 vector registers 16-31 */
+ #define NT_S390_VXRS_LOW  0x309         /* s390 vector registers 0-15 (lower half) */
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..8a92c67 100644
+index 8198be0..71601c9 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -11,7 +23,21 @@ index 8198be0..8a92c67 100644
  
  #include <sys/resource.h>
  #include <sys/shm.h>
-@@ -3193,21 +3195,21 @@ static abi_ulong vma_dump_size(const struct vm_area_struct *vma)
+@@ -2999,6 +3001,13 @@ struct target_elf_prpsinfo {
+     char    pr_psargs[ELF_PRARGSZ]; /* initial part of arg list */
+ };
+ 
++struct target_ntfile_entry {
++    abi_ulong   vm_start;
++    abi_ulong   vm_end;
++    abi_ulong   page_offset;
++    char        *path;
++};
++
+ /* Here is the structure in which status of each thread is captured. */
+ struct elf_thread_status {
+     QTAILQ_ENTRY(elf_thread_status)  ets_link;
+@@ -3193,21 +3202,21 @@ static abi_ulong vma_dump_size(const struct vm_area_struct *vma)
       * and check whether it contains elf header.  If there is
       * no elf header, we dump it.
       */
@@ -48,10 +74,88 @@ index 8198be0..8a92c67 100644
  
      return (vma->vma_end - vma->vma_start);
  }
-@@ -3357,6 +3359,19 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
+@@ -3357,6 +3366,97 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
      }
  }
  
++static void fill_ntfile_note(struct memelfnote *note, TaskState *ts)
++{
++    GSList *map_info = read_self_maps();
++    GSList *s;
++    int count = 0;
++    int data_size = sizeof(abi_long)*2; // reserve space for num_map_entry and page_size
++    struct target_ntfile_entry *entries = NULL;
++
++    // grab memory mapping first
++    for (s = map_info; s; s = g_slist_next(s)) {
++        MapInfo *e = (MapInfo *) s->data;
++
++        if (h2g_valid(e->start)) {
++            unsigned long min = e->start;
++            unsigned long max = e->end;
++            int flags = page_get_flags(h2g(min));
++            const char *path;
++
++            max = h2g_valid(max - 1) ?
++                max : (uintptr_t) g2h(GUEST_ADDR_MAX) + 1;
++
++            if (page_check_range(h2g(min), max - min, flags) == -1) {
++                continue;
++            }
++
++            if (h2g(min) == ts->info->stack_limit) {
++                path = "[stack]";
++            } else {
++                path = e->path;
++            }
++
++            count++;
++            entries = realloc(entries, sizeof(struct target_ntfile_entry)*count);
++            struct target_ntfile_entry *entry = &entries[count-1];
++            memset(entry, 0, sizeof(*entry));
++
++            data_size += sizeof(abi_long)*3 + strlen(path) + 1;
++            entry->vm_start = h2g(min);
++            entry->vm_end = h2g(max - 1) + 1;
++            entry->page_offset = e->offset;
++            entry->path = strdup(path);
++        }
++    }
++
++    // prepare the memory mapping in NT_FILE format
++    char *ptr;
++    int idx = 0;
++    ptr = (char *)g_malloc0(data_size);
++    abi_long *long_ptr = (abi_long *)ptr;
++
++    // memory mappings
++    long_ptr[idx++] = count;    // number of map entries
++    long_ptr[idx++] = TARGET_PAGE_SIZE;   // target page size
++    for(int i=0; i<count; i++) {
++        struct target_ntfile_entry *entry = &entries[i];
++        long_ptr[idx++] = entry->vm_start;
++        long_ptr[idx++] = entry->vm_end;
++        long_ptr[idx++] = entry->page_offset;
++    }
++
++    // path names
++    idx *= sizeof(abi_long);
++    for(int i=0; i<count; i++) {
++        struct target_ntfile_entry *entry = &entries[i];
++        int path_size = strlen(entry->path);
++        strcpy(&ptr[idx], entry->path);
++        idx += path_size + 1;
++        free(entry->path);
++    }
++
++    // write it out
++    fill_note(note, "CORE", NT_FILE, data_size, ptr);
++
++    // cleanup
++    free(entries);
++    free_self_maps(map_info);
++}
++
 +const char *coredump_prefix = ".";
 +void qemu_set_core_dump_prefix(const char *prefix)
 +{
@@ -68,7 +172,7 @@ index 8198be0..8a92c67 100644
  /*
   * Constructs name of coredump file.  We have following convention
   * for the name:
-@@ -3383,7 +3398,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
+@@ -3383,7 +3483,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
      base_filename = g_path_get_basename(ts->bprm->filename);
      (void) strftime(timestamp, sizeof (timestamp), "%Y%m%d-%H%M%S",
                      localtime_r(&tv.tv_sec, &tm));
@@ -77,6 +181,34 @@ index 8198be0..8a92c67 100644
                      base_filename, timestamp, (int)getpid());
      g_free(base_filename);
  
+@@ -3487,7 +3587,7 @@ static void init_note_info(struct elf_note_info *info)
+ static int fill_note_info(struct elf_note_info *info,
+                           long signr, const CPUArchState *env)
+ {
+-#define NUMNOTES 3
++#define NUMNOTES 4
+     CPUState *cpu = env_cpu((CPUArchState *)env);
+     TaskState *ts = (TaskState *)cpu->opaque;
+     int i;
+@@ -3504,7 +3604,7 @@ static int fill_note_info(struct elf_note_info *info,
+ 
+     /*
+      * First fill in status (and registers) of current thread
+-     * including process info & aux vector.
++     * including process info, aux vector & memory mapping.
+      */
+     fill_prstatus(info->prstatus, ts, signr);
+     elf_core_copy_regs(&info->prstatus->pr_reg, env);
+@@ -3514,7 +3614,8 @@ static int fill_note_info(struct elf_note_info *info,
+     fill_note(&info->notes[1], "CORE", NT_PRPSINFO,
+               sizeof (*info->psinfo), info->psinfo);
+     fill_auxv_note(&info->notes[2], ts);
+-    info->numnote = 3;
++    fill_ntfile_note(&info->notes[3], ts);
++    info->numnote = NUMNOTES;
+ 
+     info->notes_size = 0;
+     for (i = 0; i < info->numnote; i++)
 diff --git a/linux-user/main.c b/linux-user/main.c
 index 22578b1..ee5ca09 100644
 --- a/linux-user/main.c

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -1,8 +1,8 @@
 diff --git a/accel/tcg/cpu-exec.c b/accel/tcg/cpu-exec.c
-index d95c484..e50d65e 100644
+index d95c484..6777c13 100644
 --- a/accel/tcg/cpu-exec.c
 +++ b/accel/tcg/cpu-exec.c
-@@ -138,6 +138,17 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
+@@ -138,6 +138,28 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
  #endif /* CONFIG USER ONLY */
  
  /* Execute a TB, and fix up the CPU state afterwards if necessary */
@@ -16,22 +16,52 @@ index d95c484..e50d65e 100644
 +    }
 +}
 +
++abi_long trace_start_addr = 0;
++static int trace_started = 0;
++void qemu_set_trace_start_addr(const char *addr_str)
++{
++    int ret = sscanf(addr_str, "0x" TARGET_FMT_lx, &trace_start_addr);
++    if(ret != 1) {
++        fprintf(stderr, "Fail to parse trace_start_addr: '%s'\n", addr_str);
++        exit(1);
++    }
++}
++
 +extern int elf_core_dump(int signr, const CPUArchState *env);
  static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
  {
      CPUArchState *env = cpu->env_ptr;
-@@ -153,6 +164,11 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
-                            itb->cs_base, itb->pc, itb->flags,
-                            lookup_symbol(itb->pc));
+@@ -146,12 +168,24 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
+     int tb_exit;
+     uint8_t *tb_ptr = itb->tc.ptr;
  
+-    qemu_log_mask_and_addr(CPU_LOG_EXEC, itb->pc,
+-                           "Trace %d: %p ["
+-                           TARGET_FMT_lx "/" TARGET_FMT_lx "/%#x] %s\n",
+-                           cpu->cpu_index, itb->tc.ptr,
+-                           itb->cs_base, itb->pc, itb->flags,
+-                           lookup_symbol(itb->pc));
++    // decide whether to start tracing
++    if(unlikely(trace_start_addr != 0 && trace_started == 0)) {
++        if(unlikely(trace_start_addr >= itb->pc && trace_start_addr < itb->pc + itb->size)) trace_started = 1;
++    }
++
++    if(trace_started) {
++        qemu_log_mask_and_addr(CPU_LOG_EXEC, itb->pc,
++                               "Trace %d: %p ["
++                               TARGET_FMT_lx "/" TARGET_FMT_lx "/%#x] %s\n",
++                               cpu->cpu_index, itb->tc.ptr,
++                               itb->cs_base, itb->pc, itb->flags,
++                               lookup_symbol(itb->pc));
++    }
++
 +    if(unlikely(core_addr >= itb->pc && core_addr < itb->pc + itb->size)) {
 +        elf_core_dump(SIGSEGV, env);
 +        abort();
 +    }
-+
+ 
  #if defined(DEBUG_DISAS)
      if (qemu_loglevel_mask(CPU_LOG_TB_CPU)
-         && qemu_log_in_addr_range(itb->pc)) {
 diff --git a/include/elf.h b/include/elf.h
 index 8fbfe60..79e5fbc 100644
 --- a/include/elf.h
@@ -45,15 +75,16 @@ index 8fbfe60..79e5fbc 100644
  #define NT_S390_VXRS_HIGH 0x30a         /* s390 vector registers 16-31 */
  #define NT_S390_VXRS_LOW  0x309         /* s390 vector registers 0-15 (lower half) */
 diff --git a/include/exec/log.h b/include/exec/log.h
-index fcc7b9e..ca70a47 100644
+index fcc7b9e..767c6d0 100644
 --- a/include/exec/log.h
 +++ b/include/exec/log.h
-@@ -13,6 +13,9 @@
+@@ -13,6 +13,10 @@
   *
   * Logs the output of cpu_dump_state().
   */
 +
 +void qemu_set_core_addr(const char *addr_str);
++void qemu_set_trace_start_addr(const char *addr_str);
 +
  static inline void log_cpu_state(CPUState *cpu, int flags)
  {
@@ -286,10 +317,10 @@ index 8198be0..2bcc4e0 100644
      const CPUState *cpu = env_cpu((CPUArchState *)env);
      const TaskState *ts = (const TaskState *)cpu->opaque;
 diff --git a/linux-user/main.c b/linux-user/main.c
-index 22578b1..24df7d1 100644
+index 22578b1..de746bd 100644
 --- a/linux-user/main.c
 +++ b/linux-user/main.c
-@@ -288,6 +288,16 @@ static void handle_arg_stack_size(const char *arg)
+@@ -288,6 +288,21 @@ static void handle_arg_stack_size(const char *arg)
      }
  }
  
@@ -303,10 +334,15 @@ index 22578b1..24df7d1 100644
 +    qemu_set_core_addr(arg);
 +}
 +
++static void handle_arg_trace_start_addr(const char *arg)
++{
++    qemu_set_trace_start_addr(arg);
++}
++
  static void handle_arg_ld_prefix(const char *arg)
  {
      interp_prefix = strdup(arg);
-@@ -424,6 +434,10 @@ static const struct qemu_argument arg_table[] = {
+@@ -424,6 +439,12 @@ static const struct qemu_argument arg_table[] = {
       "",           ""},
      {"g",          "QEMU_GDB",         true,  handle_arg_gdb,
       "port",       "wait gdb connection to 'port'"},
@@ -314,6 +350,8 @@ index 22578b1..24df7d1 100644
 +     "path",       "set coredump path prefix to 'path' (default '.')"},
 +    {"A",          "QEMU_CORE_ADDR",   true,  handle_arg_core_addr,
 +     "coreaddr",   "generate a core dump at 'coreaddr'"},
++    {"T",          "QEMU_TRACE_START_ADDR",   true,  handle_arg_trace_start_addr,
++     "tracestart", "start tracing after tracestart address"},
      {"L",          "QEMU_LD_PREFIX",   true,  handle_arg_ld_prefix,
       "path",       "set the elf interpreter prefix to 'path'"},
      {"s",          "QEMU_STACK_SIZE",  true,  handle_arg_stack_size,

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -1,8 +1,8 @@
 diff --git a/accel/tcg/cpu-exec.c b/accel/tcg/cpu-exec.c
-index d95c484..6e97b20 100644
+index d95c484..5ffb1b0 100644
 --- a/accel/tcg/cpu-exec.c
 +++ b/accel/tcg/cpu-exec.c
-@@ -138,6 +138,29 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
+@@ -138,6 +138,30 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
  #endif /* CONFIG USER ONLY */
  
  /* Execute a TB, and fix up the CPU state afterwards if necessary */
@@ -18,7 +18,7 @@ index d95c484..6e97b20 100644
 +}
 +
 +abi_long trace_start_addr = 0;
-+static int trace_started = 0;
++static int trace_started = 1;
 +void qemu_set_trace_start_addr(const char *addr_str)
 +{
 +    int ret = sscanf(addr_str, "0x" TARGET_FMT_lx, &trace_start_addr);
@@ -26,13 +26,14 @@ index d95c484..6e97b20 100644
 +        fprintf(stderr, "Fail to parse trace_start_addr: '%s'\n", addr_str);
 +        exit(1);
 +    }
++    trace_started = 0;
 +}
 +
 +extern int elf_core_dump(int signr, const CPUArchState *env);
  static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
  {
      CPUArchState *env = cpu->env_ptr;
-@@ -146,12 +169,24 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
+@@ -146,12 +170,25 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
      int tb_exit;
      uint8_t *tb_ptr = itb->tc.ptr;
  
@@ -59,6 +60,7 @@ index d95c484..6e97b20 100644
 +    if(unlikely(core_dumped == 0 && core_addr >= itb->pc && core_addr < itb->pc + itb->size)) {
 +        elf_core_dump(SIGSEGV, env);
 +        core_dumped = 1;
++        sleep(2);// sleep 2 seconds for qemu to not overwrite the previous coredump
 +    }
  
  #if defined(DEBUG_DISAS)

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -11,7 +11,7 @@ index 8fbfe60..79e5fbc 100644
  #define NT_S390_VXRS_HIGH 0x30a         /* s390 vector registers 16-31 */
  #define NT_S390_VXRS_LOW  0x309         /* s390 vector registers 0-15 (lower half) */
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..5703f2b 100644
+index 8198be0..3921fc1 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -74,7 +74,7 @@ index 8198be0..5703f2b 100644
  
      return (vma->vma_end - vma->vma_start);
  }
-@@ -3357,6 +3366,105 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
+@@ -3357,6 +3366,107 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
      }
  }
  
@@ -90,7 +90,7 @@ index 8198be0..5703f2b 100644
 +
 +    fp = fopen("/proc/self/maps", "r");
 +    if (fp == NULL) {
-+        return -1;
++        return;
 +    }
 +
 +    // grab memory mapping first
@@ -115,6 +115,8 @@ index 8198be0..5703f2b 100644
 +            if (h2g(min) == ts->info->stack_limit) {
 +                strcpy(path, "      [stack]");
 +            }
++            // NT_FILE requires the mapping to be backed by a file
++            if (access(path, F_OK) != 0) continue;
 +
 +            count++;
 +            entries = realloc(entries, sizeof(struct target_ntfile_entry)*count);
@@ -180,7 +182,7 @@ index 8198be0..5703f2b 100644
  /*
   * Constructs name of coredump file.  We have following convention
   * for the name:
-@@ -3383,7 +3491,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
+@@ -3383,7 +3493,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
      base_filename = g_path_get_basename(ts->bprm->filename);
      (void) strftime(timestamp, sizeof (timestamp), "%Y%m%d-%H%M%S",
                      localtime_r(&tv.tv_sec, &tm));
@@ -189,7 +191,7 @@ index 8198be0..5703f2b 100644
                      base_filename, timestamp, (int)getpid());
      g_free(base_filename);
  
-@@ -3487,7 +3595,7 @@ static void init_note_info(struct elf_note_info *info)
+@@ -3487,7 +3597,7 @@ static void init_note_info(struct elf_note_info *info)
  static int fill_note_info(struct elf_note_info *info,
                            long signr, const CPUArchState *env)
  {
@@ -198,7 +200,7 @@ index 8198be0..5703f2b 100644
      CPUState *cpu = env_cpu((CPUArchState *)env);
      TaskState *ts = (TaskState *)cpu->opaque;
      int i;
-@@ -3504,7 +3612,7 @@ static int fill_note_info(struct elf_note_info *info,
+@@ -3504,7 +3614,7 @@ static int fill_note_info(struct elf_note_info *info,
  
      /*
       * First fill in status (and registers) of current thread
@@ -207,7 +209,7 @@ index 8198be0..5703f2b 100644
       */
      fill_prstatus(info->prstatus, ts, signr);
      elf_core_copy_regs(&info->prstatus->pr_reg, env);
-@@ -3514,7 +3622,8 @@ static int fill_note_info(struct elf_note_info *info,
+@@ -3514,7 +3624,8 @@ static int fill_note_info(struct elf_note_info *info,
      fill_note(&info->notes[1], "CORE", NT_PRPSINFO,
                sizeof (*info->psinfo), info->psinfo);
      fill_auxv_note(&info->notes[2], ts);

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -11,7 +11,7 @@ index 8fbfe60..79e5fbc 100644
  #define NT_S390_VXRS_HIGH 0x30a         /* s390 vector registers 16-31 */
  #define NT_S390_VXRS_LOW  0x309         /* s390 vector registers 0-15 (lower half) */
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..71601c9 100644
+index 8198be0..5703f2b 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -74,39 +74,46 @@ index 8198be0..71601c9 100644
  
      return (vma->vma_end - vma->vma_start);
  }
-@@ -3357,6 +3366,97 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
+@@ -3357,6 +3366,105 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
      }
  }
  
 +static void fill_ntfile_note(struct memelfnote *note, TaskState *ts)
 +{
-+    GSList *map_info = read_self_maps();
-+    GSList *s;
++    FILE *fp;
++    char *line = NULL;
++    size_t len = 0;
++    ssize_t read;
 +    int count = 0;
 +    int data_size = sizeof(abi_long)*2; // reserve space for num_map_entry and page_size
 +    struct target_ntfile_entry *entries = NULL;
 +
++    fp = fopen("/proc/self/maps", "r");
++    if (fp == NULL) {
++        return -1;
++    }
++
 +    // grab memory mapping first
-+    for (s = map_info; s; s = g_slist_next(s)) {
-+        MapInfo *e = (MapInfo *) s->data;
++    while ((read = getline(&line, &len, fp)) != -1) {
++        int fields, dev_maj, dev_min, inode;
++        uint64_t min, max, offset;
++        char flag_r, flag_w, flag_x, flag_p;
++        char path[512] = "";
++        fields = sscanf(line, "%"PRIx64"-%"PRIx64" %c%c%c%c %"PRIx64" %x:%x %d"
++                        " %512s", &min, &max, &flag_r, &flag_w, &flag_x,
++                        &flag_p, &offset, &dev_maj, &dev_min, &inode, path);
 +
-+        if (h2g_valid(e->start)) {
-+            unsigned long min = e->start;
-+            unsigned long max = e->end;
++        if ((fields < 10) || (fields > 11)) {
++            continue;
++        }
++        if (h2g_valid(min)) {
 +            int flags = page_get_flags(h2g(min));
-+            const char *path;
-+
-+            max = h2g_valid(max - 1) ?
-+                max : (uintptr_t) g2h(GUEST_ADDR_MAX) + 1;
-+
++            max = h2g_valid(max - 1) ? max : (uintptr_t)g2h(GUEST_ADDR_MAX) + 1;
 +            if (page_check_range(h2g(min), max - min, flags) == -1) {
 +                continue;
 +            }
-+
 +            if (h2g(min) == ts->info->stack_limit) {
-+                path = "[stack]";
-+            } else {
-+                path = e->path;
++                strcpy(path, "      [stack]");
 +            }
 +
 +            count++;
@@ -117,7 +124,7 @@ index 8198be0..71601c9 100644
 +            data_size += sizeof(abi_long)*3 + strlen(path) + 1;
 +            entry->vm_start = h2g(min);
 +            entry->vm_end = h2g(max - 1) + 1;
-+            entry->page_offset = e->offset;
++            entry->page_offset = offset;
 +            entry->path = strdup(path);
 +        }
 +    }
@@ -153,7 +160,8 @@ index 8198be0..71601c9 100644
 +
 +    // cleanup
 +    free(entries);
-+    free_self_maps(map_info);
++    free(line);
++    fclose(fp);
 +}
 +
 +const char *coredump_prefix = ".";
@@ -172,7 +180,7 @@ index 8198be0..71601c9 100644
  /*
   * Constructs name of coredump file.  We have following convention
   * for the name:
-@@ -3383,7 +3483,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
+@@ -3383,7 +3491,7 @@ static int core_dump_filename(const TaskState *ts, char *buf,
      base_filename = g_path_get_basename(ts->bprm->filename);
      (void) strftime(timestamp, sizeof (timestamp), "%Y%m%d-%H%M%S",
                      localtime_r(&tv.tv_sec, &tm));
@@ -181,7 +189,7 @@ index 8198be0..71601c9 100644
                      base_filename, timestamp, (int)getpid());
      g_free(base_filename);
  
-@@ -3487,7 +3587,7 @@ static void init_note_info(struct elf_note_info *info)
+@@ -3487,7 +3595,7 @@ static void init_note_info(struct elf_note_info *info)
  static int fill_note_info(struct elf_note_info *info,
                            long signr, const CPUArchState *env)
  {
@@ -190,7 +198,7 @@ index 8198be0..71601c9 100644
      CPUState *cpu = env_cpu((CPUArchState *)env);
      TaskState *ts = (TaskState *)cpu->opaque;
      int i;
-@@ -3504,7 +3604,7 @@ static int fill_note_info(struct elf_note_info *info,
+@@ -3504,7 +3612,7 @@ static int fill_note_info(struct elf_note_info *info,
  
      /*
       * First fill in status (and registers) of current thread
@@ -199,7 +207,7 @@ index 8198be0..71601c9 100644
       */
      fill_prstatus(info->prstatus, ts, signr);
      elf_core_copy_regs(&info->prstatus->pr_reg, env);
-@@ -3514,7 +3614,8 @@ static int fill_note_info(struct elf_note_info *info,
+@@ -3514,7 +3622,8 @@ static int fill_note_info(struct elf_note_info *info,
      fill_note(&info->notes[1], "CORE", NT_PRPSINFO,
                sizeof (*info->psinfo), info->psinfo);
      fill_auxv_note(&info->notes[2], ts);

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -217,7 +217,7 @@ index 8198be0..b1325a5 100644
 +            data_size += sizeof(abi_long)*3 + strlen(path) + 1;
 +            entry->vm_start = h2g(min);
 +            entry->vm_end = h2g(max - 1) + 1;
-+            entry->page_offset = offset;
++            entry->page_offset = offset / TARGET_PAGE_SIZE;
 +            entry->path = strdup(path);
 +        }
 +    }

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -1,5 +1,5 @@
 diff --git a/linux-user/elfload.c b/linux-user/elfload.c
-index 8198be0..a2431c3 100644
+index 8198be0..8a92c67 100644
 --- a/linux-user/elfload.c
 +++ b/linux-user/elfload.c
 @@ -1,6 +1,8 @@
@@ -8,13 +8,50 @@ index 8198be0..a2431c3 100644
  #include <sys/param.h>
 +#include <sys/types.h>
 +#include <sys/stat.h>
-
+ 
  #include <sys/resource.h>
  #include <sys/shm.h>
+@@ -3193,21 +3195,21 @@ static abi_ulong vma_dump_size(const struct vm_area_struct *vma)
+      * and check whether it contains elf header.  If there is
+      * no elf header, we dump it.
+      */
+-    if (vma->vma_flags & PROT_EXEC) {
+-        char page[TARGET_PAGE_SIZE];
+-
+-        copy_from_user(page, vma->vma_start, sizeof (page));
+-        if ((page[EI_MAG0] == ELFMAG0) &&
+-            (page[EI_MAG1] == ELFMAG1) &&
+-            (page[EI_MAG2] == ELFMAG2) &&
+-            (page[EI_MAG3] == ELFMAG3)) {
+-            /*
+-             * Mappings are possibly from ELF binary.  Don't dump
+-             * them.
+-             */
+-            return (0);
+-        }
+-    }
++    // if (vma->vma_flags & PROT_EXEC) {
++    //     char page[TARGET_PAGE_SIZE];
++
++    //     copy_from_user(page, vma->vma_start, sizeof (page));
++    //     if ((page[EI_MAG0] == ELFMAG0) &&
++    //         (page[EI_MAG1] == ELFMAG1) &&
++    //         (page[EI_MAG2] == ELFMAG2) &&
++    //         (page[EI_MAG3] == ELFMAG3)) {
++    //         /*
++    //          * Mappings are possibly from ELF binary.  Don't dump
++    //          * them.
++    //          */
++    //         return (0);
++    //     }
++    // }
+ 
+     return (vma->vma_end - vma->vma_start);
+ }
 @@ -3357,6 +3359,19 @@ static void fill_auxv_note(struct memelfnote *note, const TaskState *ts)
      }
  }
-
+ 
 +const char *coredump_prefix = ".";
 +void qemu_set_core_dump_prefix(const char *prefix)
 +{
@@ -39,7 +76,7 @@ index 8198be0..a2431c3 100644
 +    (void) snprintf(buf, bufsize, "%s/qemu_%s_%s_%d.core", coredump_prefix,
                      base_filename, timestamp, (int)getpid());
      g_free(base_filename);
-
+ 
 diff --git a/linux-user/main.c b/linux-user/main.c
 index 22578b1..ee5ca09 100644
 --- a/linux-user/main.c
@@ -47,7 +84,7 @@ index 22578b1..ee5ca09 100644
 @@ -288,6 +288,11 @@ static void handle_arg_stack_size(const char *arg)
      }
  }
-
+ 
 +static void handle_arg_core(const char *arg)
 +{
 +    qemu_set_core_dump_prefix(arg);
@@ -74,7 +111,7 @@ index 792c742..f59c86d 100644
  int load_elf_binary(struct linux_binprm *bprm, struct image_info *info);
  int load_flt_binary(struct linux_binprm *bprm, struct image_info *info);
 +void qemu_set_core_dump_prefix(const char *prefix);
-
+ 
  abi_long memcpy_to_target(abi_ulong dest, const void *src,
                            unsigned long len);
 diff --git a/linux-user/signal.c b/linux-user/signal.c
@@ -87,13 +124,13 @@ index 8cf51ff..3322d2c 100644
      struct sigaction act;
 +    target_ulong cs_base, pc;
 +    uint32_t flags;
-
+ 
      host_sig = target_to_host_signal(target_sig);
      trace_user_force_sig(env, target_sig, host_sig);
 @@ -649,6 +651,16 @@ static void QEMU_NORETURN dump_core_and_abort(int target_sig)
              target_sig, strsignal(host_sig), "core dumped" );
      }
-
+ 
 +    cpu_get_tb_cpu_state(env, &pc, &cs_base, &flags);
 +    if (sizeof(target_ulong) == 4) {
 +        qemu_log("qemu: uncaught target signal %d (%s) - %s [%08x]\n",
@@ -107,5 +144,3 @@ index 8cf51ff..3322d2c 100644
      /* The proper exit code for dying from an uncaught signal is
       * -<signal>.  The kernel doesn't allow exit() or _exit() to pass
       * a negative value.  To get the proper exit code we need to
---
-2.17.1

--- a/patches/linux-coredump.patch
+++ b/patches/linux-coredump.patch
@@ -1,12 +1,13 @@
 diff --git a/accel/tcg/cpu-exec.c b/accel/tcg/cpu-exec.c
-index d95c484..6777c13 100644
+index d95c484..6e97b20 100644
 --- a/accel/tcg/cpu-exec.c
 +++ b/accel/tcg/cpu-exec.c
-@@ -138,6 +138,28 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
+@@ -138,6 +138,29 @@ static void init_delay_params(SyncClocks *sc, const CPUState *cpu)
  #endif /* CONFIG USER ONLY */
  
  /* Execute a TB, and fix up the CPU state afterwards if necessary */
 +abi_long core_addr = 0;
++abi_long core_dumped = 0;
 +void qemu_set_core_addr(const char *addr_str)
 +{
 +    int ret = sscanf(addr_str, "0x" TARGET_FMT_lx, &core_addr);
@@ -31,7 +32,7 @@ index d95c484..6777c13 100644
  static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
  {
      CPUArchState *env = cpu->env_ptr;
-@@ -146,12 +168,24 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
+@@ -146,12 +169,24 @@ static inline tcg_target_ulong cpu_tb_exec(CPUState *cpu, TranslationBlock *itb)
      int tb_exit;
      uint8_t *tb_ptr = itb->tc.ptr;
  
@@ -55,9 +56,9 @@ index d95c484..6777c13 100644
 +                               lookup_symbol(itb->pc));
 +    }
 +
-+    if(unlikely(core_addr >= itb->pc && core_addr < itb->pc + itb->size)) {
++    if(unlikely(core_dumped == 0 && core_addr >= itb->pc && core_addr < itb->pc + itb->size)) {
 +        elf_core_dump(SIGSEGV, env);
-+        abort();
++        core_dumped = 1;
 +    }
  
  #if defined(DEBUG_DISAS)


### PR DESCRIPTION
CHANGE LIST
1. NT_FILE support in core dump
2. allow generating coredump of a live process without killing it
3. allow recording traces after a certain address
4. disable block break up in mips